### PR TITLE
Add AWS Lambda MCP Cookbook blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Each blueprint includes the infrastructure as code (IaC) tool, CI/CD pipeline, p
     <td>Python</td>
   </tr>
   <tr>
+    <td><a href="https://github.com/ran-isenberg/aws-lambda-mcp-cookbook">AWS Lambda MCP Cookbook</a></td>
+    <td><a href="https://ranthebuilder.com/">Ran Isenberg</a></td>
+    <td><img src="https://img.shields.io/github/stars/ran-isenberg/aws-lambda-mcp-cookbook?style=social" height="25"/></td>
+    <td>A working, deployable serverless MCP server blueprint built on AWS Lambda with AWS CDK, offering both a native Lambda implementation and a Lambda Web Adapter + FastMCP variant, with a full CI/CD pipeline, tests, and observability.</td>
+    <td>AWS CDK</td>
+    <td>GitHub Actions</td>
+    <td>Python</td>
+  </tr>
+  <tr>
     <td><a href="https://github.com/open-constructs/cdk-serverless">CDK Serverless</a></td>
     <td><a href="https://github.com/hoegertn/">Thorsten Hoeger</a></td>
     <td><img src="https://img.shields.io/github/stars/open-constructs/cdk-serverless?style=social" height="25"/></td>

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Each blueprint includes the infrastructure as code (IaC) tool, CI/CD pipeline, p
   </tr>
   <tr>
     <td><a href="https://github.com/ran-isenberg/auto-cross-account-access-service">Auto Cross-Account Access Service</a></td>
-    <td><a href="https://ranthebuilder.com/">Ran Isenberg</a></td>
+    <td><a href="https://ranthebuilder.cloud/">Ran Isenberg</a></td>
     <td><img src="https://img.shields.io/github/stars/ran-isenberg/auto-cross-account-access-service?style=social" height="25"/></td>
     <td>A serverless service that automates cross-account secure access management between AWS accounts using IAM, AWS Service Catalog and Serverless services.</td>
     <td>AWS CDK</td>
@@ -42,7 +42,7 @@ Each blueprint includes the infrastructure as code (IaC) tool, CI/CD pipeline, p
   </tr>
   <tr>
     <td><a href="https://github.com/ran-isenberg/aws-lambda-handler-cookbook">AWS Lambda Handler Cookbook</a></td>
-    <td><a href="https://ranthebuilder.com/">Ran Isenberg</a></td>
+    <td><a href="https://ranthebuilder.cloud/">Ran Isenberg</a></td>
     <td><img src="https://img.shields.io/github/stars/ran-isenberg/aws-lambda-handler-cookbook?style=social" height="25"/></td>
     <td>A comprehensive blueprint for building optimized backend services usingb AWS Lambda functions, API GW, DynamoDB, WAF and CloudWatch using best practices for serverless architecture.</td>
     <td>AWS CDK</td>
@@ -51,7 +51,7 @@ Each blueprint includes the infrastructure as code (IaC) tool, CI/CD pipeline, p
   </tr>
   <tr>
     <td><a href="https://github.com/ran-isenberg/aws-lambda-mcp-cookbook">AWS Lambda MCP Cookbook</a></td>
-    <td><a href="https://ranthebuilder.com/">Ran Isenberg</a></td>
+    <td><a href="https://ranthebuilder.cloud/">Ran Isenberg</a></td>
     <td><img src="https://img.shields.io/github/stars/ran-isenberg/aws-lambda-mcp-cookbook?style=social" height="25"/></td>
     <td>A working, deployable serverless MCP server blueprint built on AWS Lambda with AWS CDK, offering both a native Lambda implementation and a Lambda Web Adapter + FastMCP variant, with a full CI/CD pipeline, tests, and observability.</td>
     <td>AWS CDK</td>
@@ -69,7 +69,7 @@ Each blueprint includes the infrastructure as code (IaC) tool, CI/CD pipeline, p
   </tr>
    <tr>
     <td><a href="https://github.com/ran-isenberg/governance-sample-aws-service-catalog">Governance Sample AWS Service Catalog</a></td>
-    <td><a href="https://ranthebuilder.com/">Ran Isenberg</a></td>
+    <td><a href="https://ranthebuilder.cloud/">Ran Isenberg</a></td>
     <td><img src="https://img.shields.io/github/stars/ran-isenberg/governance-sample-aws-service-catalog?style=social" height="25"/></td>
     <td>Cross-account governance, resource lifecycle management for platform teams. A governance sample built with AWS Service Catalog to help streamline approvals and resource management.</td>
     <td>AWS CDK</td>


### PR DESCRIPTION
## Summary
- Adds a new entry for [aws-lambda-mcp-cookbook](https://github.com/ran-isenberg/aws-lambda-mcp-cookbook) — a serverless MCP server blueprint built on AWS Lambda with AWS CDK (Python).
- Inserted in alphabetical order between "AWS Lambda Handler Cookbook" and "CDK Serverless".
- Provides two implementation options: a native Lambda function and a Lambda Web Adapter + FastMCP variant; ships with a full CI/CD pipeline, tests, and observability.

## Test plan
- [ ] Render the README on GitHub and confirm the new row displays correctly
- [ ] Verify the alphabetical placement
- [ ] Verify all links resolve (blueprint, maintainer, stars badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)